### PR TITLE
add python DNS update script

### DIFF
--- a/updatens.py
+++ b/updatens.py
@@ -6,18 +6,23 @@ from itertools import islice
 
 import dns
 import dns.query
+import dns.resolver
 import dns.tsigkeyring
 import requests
 
-host_ip = str(socket.gethostbyname("magrathea.aachalon.de"))
+zone = "nodes.ffac.rocks"
+
+# resolve the IP of the AXFR target dynamically by reading the SOA record
+resolver = dns.resolver.Resolver()
+soa_answer = resolver.resolve(zone, dns.rdatatype.SOA)
+host_ip = str(socket.gethostbyname(str(soa_answer[0].mname)))
 # xfr is only allowed coming from the monitor or DNS host
 
-# somehow it does not work using our dns for now
+# somehow it does not work using our own dns for now
 # DNS_SERVER = str(socket.gethostbyname('dns.freifunk-aachen.de'))
 DNS_SERVER = "8.8.8.8"
 DEBUG = False
 
-zone = "nodes.ffac.rocks"
 key_name = "nodes.ffac.rocks."
 key_secret = os.getenv("ZONE_SECRET_KEY", "")
 key_algorithm = "hmac-sha512"

--- a/updatens.py
+++ b/updatens.py
@@ -1,0 +1,84 @@
+#! /usr/env/python3
+# requires requests, dnspython
+import os
+from itertools import islice
+
+import requests
+from dns.tsigkeyring import from_text
+from dns.update import Update
+from dns.query import tcp
+
+
+def batched(iterable, n):
+    # if python >= 3.12:
+    # from itertools import batched
+    # https://docs.python.org/3/library/itertools.html#itertools.batched
+    # batched('ABCDEFG', 3) → ABC DEF G
+    if n < 1:
+        raise ValueError("n must be at least one")
+    it = iter(iterable)
+    while batch := tuple(islice(it, n)):
+        yield batch
+
+
+dns_server = "8.8.8.8"
+zone = "nodes.ffac.rocks"
+key_name = "nodes.ffac.rocks."
+key_secret = os.getenv("SECRET_KEY", "")
+key_algorithm = "hmac-sha512"
+keyring = from_text({key_name: key_secret})
+url = "https://map.aachen.freifunk.net/data/nodes.json"
+
+t = requests.get(url)
+t.raise_for_status()
+nodes = t.json()["nodes"]
+
+# Parse the key data and create a TSIG keyring
+pairs = []
+for node in nodes:
+    nodeinfo = node["nodeinfo"]
+    addrs = nodeinfo["network"]["addresses"]
+    addrs = list(filter(lambda x: not x.startswith("f"), addrs))
+    host = nodeinfo["hostname"]
+    replacements = ["`", "´", ".", " "]
+    for rep in replacements:
+        host = host.replace(rep, "-")
+    host = host.encode("idna").decode()
+
+    pairs.append((host, addrs))
+
+# nsupdate can only handle 400 requests at once
+n = 400
+# pairs = sorted(filter(lambda x: "herrengarten" in x[0],pairs))
+for batch in batched(sorted(pairs), n):
+    update = Update(zone, keyring=keyring)
+    for host, addrs in batch:
+        dns_name = f"{host}.{zone}"
+        update.replace(dns_name, 300, "AAAA", addrs[0])
+    response = tcp(update, dns_server)
+    print(response)
+
+
+
+# for batch in batched(sorted(pairs), n):
+#     update = Update(zone, keyring=keyring)
+#     for host, addrs in batch:
+#         dns_name = f"{host}.{zone}"
+
+#         import dns
+#         rdataset = dns.rdataset.Rdataset(dns.rdataclass.IN, dns.rdatatype.AAAA, ttl=300)
+        
+#         #for addr in addrs:
+#         rdata = dns.rdata.from_text(dns.rdataclass.IN, dns.rdatatype.AAAA, addrs[0])
+#         rdataset.add(rdata)
+#         #if dns_name in list(map(lambda x: str(x.name), update.update)):
+#             #update.replace(dns_name, 300, "AAAA", addr)
+#         #else:
+#         update.delete(dns_name, rdataset)
+
+#         ### alternative 2
+#         if dns_name in list(map(lambda x: str(x.name), update.update)):
+#             pass
+#             #update.replace(dns_name, 300, "AAAA", addr)
+#         else:
+#             update.replace(dns_name, 300, "AAAA", addrs[0])

--- a/updatens.py
+++ b/updatens.py
@@ -1,12 +1,34 @@
 #! /usr/env/python3
 # requires requests, dnspython
 import os
+import socket
 from itertools import islice
 
+import dns
+import dns.query
+import dns.tsigkeyring
 import requests
-from dns.tsigkeyring import from_text
-from dns.update import Update
-from dns.query import tcp
+
+host_ip = str(socket.gethostbyname("magrathea.aachalon.de"))
+# xfr is only allowed coming from the monitor or DNS host
+
+# somehow it does not work using our dns for now
+# DNS_SERVER = str(socket.gethostbyname('dns.freifunk-aachen.de'))
+DNS_SERVER = "8.8.8.8"
+DEBUG = False
+
+zone = "nodes.ffac.rocks"
+key_name = "nodes.ffac.rocks."
+key_secret = os.getenv("ZONE_SECRET_KEY", "")
+key_algorithm = "hmac-sha512"
+# Parse the key data and create a TSIG keyring
+KEYRING = dns.tsigkeyring.from_text({key_name: key_secret})
+# url from which the current state is crawled
+url = "https://map.aachen.freifunk.net/data/nodes.json"
+
+# nsupdate can only handle 300-400 requests at once
+# so we are running in batches of 300
+BATCH_SIZE = 300
 
 
 def batched(iterable, n):
@@ -21,64 +43,109 @@ def batched(iterable, n):
         yield batch
 
 
-dns_server = "8.8.8.8"
-zone = "nodes.ffac.rocks"
-key_name = "nodes.ffac.rocks."
-key_secret = os.getenv("SECRET_KEY", "")
-key_algorithm = "hmac-sha512"
-keyring = from_text({key_name: key_secret})
-url = "https://map.aachen.freifunk.net/data/nodes.json"
+def crawl_pairs_from_map(url):
+    t = requests.get(url)
+    t.raise_for_status()
+    nodes = t.json()["nodes"]
 
-t = requests.get(url)
-t.raise_for_status()
-nodes = t.json()["nodes"]
+    pairs = []
+    for node in nodes:
+        nodeinfo = node["nodeinfo"]
+        addrs = nodeinfo["network"]["addresses"]
+        addrs = list(filter(lambda x: not x.startswith("f"), addrs))
+        host = nodeinfo["hostname"]
+        replacements = ["`", "´", ".", " "]
+        for rep in replacements:
+            host = host.replace(rep, "-")
+        host = host.encode("idna").decode().lower()
 
-# Parse the key data and create a TSIG keyring
-pairs = []
-for node in nodes:
-    nodeinfo = node["nodeinfo"]
-    addrs = nodeinfo["network"]["addresses"]
-    addrs = list(filter(lambda x: not x.startswith("f"), addrs))
-    host = nodeinfo["hostname"]
-    replacements = ["`", "´", ".", " "]
-    for rep in replacements:
-        host = host.replace(rep, "-")
-    host = host.encode("idna").decode()
+        pairs.append((host, addrs))
 
-    pairs.append((host, addrs))
-
-# nsupdate can only handle 400 requests at once
-n = 400
-# pairs = sorted(filter(lambda x: "herrengarten" in x[0],pairs))
-for batch in batched(sorted(pairs), n):
-    update = Update(zone, keyring=keyring)
-    for host, addrs in batch:
-        dns_name = f"{host}.{zone}"
-        update.replace(dns_name, 300, "AAAA", addrs[0])
-    response = tcp(update, dns_server)
-    print(response)
+    return list(sorted(pairs))
 
 
+def crawl_stat_from_xfr(host_ip, zone):
+    zone_entries = list(dns.query.xfr(host_ip, zone))
+    current_entries = {}
+    for dns_message in zone_entries:
+        # dns_message has 4 sections
+        # second section contains dns names, others are irrelevant
+        print("entries in msg", dns_message.sections[1])
+        filt = filter(lambda e: e.rdtype == dns.rdatatype.AAAA, dns_message.sections[1])
+        for entry in filt:
+            # print(entry.name, list(map(lambda x: str(x), entry.items.keys())))
+            current_entries[str(entry.name)] = list(
+                map(lambda x: str(x), entry.items.keys())
+            )
+    return current_entries
 
-# for batch in batched(sorted(pairs), n):
-#     update = Update(zone, keyring=keyring)
-#     for host, addrs in batch:
-#         dns_name = f"{host}.{zone}"
 
-#         import dns
-#         rdataset = dns.rdataset.Rdataset(dns.rdataclass.IN, dns.rdatatype.AAAA, ttl=300)
-        
-#         #for addr in addrs:
-#         rdata = dns.rdata.from_text(dns.rdataclass.IN, dns.rdatatype.AAAA, addrs[0])
-#         rdataset.add(rdata)
-#         #if dns_name in list(map(lambda x: str(x.name), update.update)):
-#             #update.replace(dns_name, 300, "AAAA", addr)
-#         #else:
-#         update.delete(dns_name, rdataset)
+def replace_changed_entries(changed_pairs, zone):
+    for batch in batched(changed_pairs, BATCH_SIZE):
+        update = dns.update.Update(zone, keyring=KEYRING)
+        for host, addrs in pairs:
+            dns_name = f"{host}.{zone}"
+            # to add multiple for a single host, we need this Rdataset type
+            rdataset = dns.rdataset.Rdataset(
+                dns.rdataclass.IN, dns.rdatatype.AAAA, ttl=300
+            )
+            for addr in addrs:
+                rdata = dns.rdata.from_text(dns.rdataclass.IN, dns.rdatatype.AAAA, addr)
+                rdataset.add(rdata)
+            update.replace(dns_name, rdataset)
+        response = dns.query.tcp(update, DNS_SERVER)
+        print(response)
 
-#         ### alternative 2
-#         if dns_name in list(map(lambda x: str(x.name), update.update)):
-#             pass
-#             #update.replace(dns_name, 300, "AAAA", addr)
-#         else:
-#             update.replace(dns_name, 300, "AAAA", addrs[0])
+
+def delete_leftover_hosts(to_remove: list, zone):
+    for batch in batched(to_remove, BATCH_SIZE):
+        update = dns.update.Update(zone, keyring=KEYRING)
+        for host, _ in batch:
+            dns_name = f"{host}.{zone}"
+            update.delete(dns_name, dns.rdatatype.AAAA)
+        response = dns.query.tcp(update, DNS_SERVER)
+        print(response)
+
+
+if __name__ == "__main__":
+    pairs = crawl_pairs_from_map(url)
+    current_entries = crawl_stat_from_xfr(host_ip, zone)
+    # gives TransferError: Zone transfer error: REFUSED
+    # if sent from IP address which is not eligible
+
+    # now copy the current_entries and check which are still as needed
+    entries = current_entries.copy()
+    to_replace = []
+    for host, addrs in pairs:
+        try:
+            # in any case, remove the entry, so that everything else can be deleted
+            current_addrs = entries.pop(host)
+        except KeyError:
+            current_addrs = [None]
+
+        # if the addresses are not as expected - we need to replace them
+        if sorted(addrs) != sorted(current_addrs):
+            to_replace.append((host, addrs))
+
+    to_remove = []
+    # we can now add the leftovers to our remove list
+    for host, addrs in entries.items():
+        to_remove.append((host, addrs))
+    # to_remove now only contains entries which are not valid anymore
+
+    if DEBUG:
+        import json
+
+        print("anzahl einträge", len(current_entries))
+
+        with open("current_entries.json", "w") as f:
+            json.dump(current_entries, f, indent=4)
+
+        with open("to_replace.json", "w") as f:
+            json.dump(to_replace, f, indent=4)
+
+        with open("to_remove.json", "w") as f:
+            json.dump(to_remove, f, indent=4)
+    else:
+        replace_changed_entries(to_replace, zone)
+        delete_leftover_hosts(to_remove, zone)


### PR DESCRIPTION
This removes the weird bash dns update scripts through more readable code (hopefully).

This relies on the executing host having permission to request the existing records in the zone through an XFR request.

We therefore do not need to keep the state updated in a file.

There is a debug mode, which makes it possible to not issue any updates and just write the would-have-changed json files to disk.